### PR TITLE
Increase heap size for the test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ repositories {
 
 test {
     useJUnitPlatform()
+    minHeapSize = "8g" // initial heap size
+    maxHeapSize = "16g" // maximum heap size
 }
 
 dependencies {


### PR DESCRIPTION
Tested with:

```
byte[][] largeArray = new byte[4][2147483640]; // 8G
```
